### PR TITLE
User's services and GenericDao refactored, UserAttendeeStateEnum added.

### DIFF
--- a/src/main/java/com/github/admissionCommittee/dao/GenericDao.java
+++ b/src/main/java/com/github/admissionCommittee/dao/GenericDao.java
@@ -1,12 +1,13 @@
 package com.github.admissionCommittee.dao;
 
+import com.github.admissionCommittee.model.AbstractEntity;
 import com.github.admissionCommittee.util.HibernateUtil;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
 import java.util.List;
 
-public abstract class GenericDao<T> {
+public abstract class GenericDao<T extends AbstractEntity> {
 
     private Class<T> type;
     private Session session;
@@ -16,15 +17,25 @@ public abstract class GenericDao<T> {
         this.type = type;
     }
 
-    public void create(T instance) {
+    public void save(T instance) {
         openSessionWithTransaction();
-        session.save(instance);
+        if (instance.isNew()) {
+            session.save(instance);
+        } else {
+            session.update(instance);
+        }
         closeSessionWithTransaction();
     }
 
-    public void update(T instance) {
+    public void save(List<T> instance) {
         openSessionWithTransaction();
-        session.update(instance);
+        instance.parallelStream().forEachOrdered(t -> {
+            if (t.isNew()) {
+                session.save(instance);
+            } else {
+                session.update(instance);
+            }
+        });
         closeSessionWithTransaction();
     }
 

--- a/src/main/java/com/github/admissionCommittee/model/User.java
+++ b/src/main/java/com/github/admissionCommittee/model/User.java
@@ -1,5 +1,6 @@
 package com.github.admissionCommittee.model;
 
+import com.github.admissionCommittee.model.enums.UserAttendeeState;
 import com.github.admissionCommittee.model.enums.UserTypeEnum;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -41,6 +42,10 @@ public class User extends AbstractEntity {
     @Column(name = "userRole", nullable = false)
     private UserTypeEnum userRole;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "userAttendeeStatus",nullable = false)
+    private UserAttendeeState userAttendeeState;
+
     @Column(name = "first_name", nullable = false)
     private String firstName;
 
@@ -60,6 +65,7 @@ public class User extends AbstractEntity {
     @Column(name = "birth_date")
     private LocalDate birthDate;
 
+    @Deprecated
     @Column(name = "is_enlisted")
     private boolean enlisted;
 

--- a/src/main/java/com/github/admissionCommittee/model/enums/UserAttendeeState.java
+++ b/src/main/java/com/github/admissionCommittee/model/enums/UserAttendeeState.java
@@ -1,0 +1,8 @@
+package com.github.admissionCommittee.model.enums;
+
+public enum UserAttendeeState {
+    ABSENTEE,
+    CHALLENGER,
+    STUDENT,
+    EXCLUDED
+}

--- a/src/main/java/com/github/admissionCommittee/service/GenericService.java
+++ b/src/main/java/com/github/admissionCommittee/service/GenericService.java
@@ -19,11 +19,13 @@ public abstract class GenericService<T extends AbstractEntity> {
     public void save(T instance) {
         Validator.validateNotNull(instance, Validator
                 .MESSAGE_FOR_SOURCE_IF_NULL);
-        if (instance.isNew()) {
-            getDao().create(instance);
-        }else{
-            getDao().update(instance);
-        }
+        getDao().save(instance);
+    }
+
+    public void save(List<T> instance) {
+        Validator.validateNotNull(instance, Validator
+                .MESSAGE_FOR_SOURCE_IF_NULL);
+        getDao().save(instance);
     }
 
     public T get(long id) {

--- a/src/main/java/com/github/admissionCommittee/util/Initializer.java
+++ b/src/main/java/com/github/admissionCommittee/util/Initializer.java
@@ -23,7 +23,6 @@ import java.time.Month;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class Initializer {
@@ -93,17 +92,17 @@ final class Initializer {
         final Subject subjectGeography = new Subject(SubjectNameEnum.GEOGRAPHY);
 
         final SubjectDao subjectDao = DaoFactory.getDaoFactory().getSubjectDao();
-        subjectDao.create(subjectPhysics);
-        subjectDao.create(subjectInformatics);
-        subjectDao.create(subjectChemistry);
-        subjectDao.create(subjectBiology);
-        subjectDao.create(subjectEnglish);
-        subjectDao.create(subjectHistory);
-        subjectDao.create(subjectRussian);
-        subjectDao.create(subjectLiterature);
-        subjectDao.create(subjectAlgebra);
-        subjectDao.create(subjectGeometry);
-        subjectDao.create(subjectGeography);
+        subjectDao.save(subjectPhysics);
+        subjectDao.save(subjectInformatics);
+        subjectDao.save(subjectChemistry);
+        subjectDao.save(subjectBiology);
+        subjectDao.save(subjectEnglish);
+        subjectDao.save(subjectHistory);
+        subjectDao.save(subjectRussian);
+        subjectDao.save(subjectLiterature);
+        subjectDao.save(subjectAlgebra);
+        subjectDao.save(subjectGeometry);
+        subjectDao.save(subjectGeography);
 
         // init faculties
         final Faculty facultyStomatology = new Faculty(
@@ -461,6 +460,10 @@ final class Initializer {
 //        final User userByMail2 = userService.getByMail("kad@epam.com");
 //        final User userByMail3 = userService.getByMail("kad@epam.com");
 
+    }
+
+    public static void main(String[] args) {
+        System.out.println(true);
     }
 
 }


### PR DESCRIPTION
🏹 _GenericDao upgraded:_
+ save(List<T> instance) added -> the number of sessions, transactions decreased for collections saving; 
+ save(T instance) refactored -> code size decreazed; 

🏹 _User: added field UserAttendeeState to be used after statements of approval;
UserAttendeeState enam added;
GenericService and UserService refactored: updating the attendee state to DB added;_
+ afted admin's finallization (during the creating the approval statements) the user's field will get one of two values (if he not non-participant) - EXCLUDED or STUDENT (fromCHALLENGER) -> the front-side can get the new status after decision of the admission comittee;


